### PR TITLE
zmk-config: enable configuration settings needed for settings system

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -58,7 +58,7 @@ manifest:
       import: false
       west-commands: scripts/west-commands.yml
     - name: zmk
-      revision: 81f471c0a569853b2adc30ca49c7f4e6f1e63e9a
+      revision: 691348abff0c46664705c57b03478254670ce58c
       remote: danieldegrasse
       path: apps/zmk
       import: false

--- a/zmk-config/flexeval.conf
+++ b/zmk-config/flexeval.conf
@@ -9,5 +9,9 @@ CONFIG_NEWLIB_LIBC=y
 # Enable watchdog support
 CONFIG_ZMK_WATCHDOG=y
 # Confirm MCUBoot image after boot
-CONFIG_FLASH=y
 CONFIG_IMG_MANAGER=y
+# Support ZMK settings
+CONFIG_ZMK_SETTINGS=y
+CONFIG_NVS=y
+CONFIG_FLASH_MAP=y
+CONFIG_FLASH=y


### PR DESCRIPTION
Enable configuration settings needed for the settings system, so we can use it with FlexEval board. Add ZMK revision needed to use the settings subsystem for dynamic keymaps.